### PR TITLE
コンテキストメニュー内に現在再生中の曲情報を表示する機能を追加した

### DIFF
--- a/NowPlayingV2/UI/Extension/NullVisibilityConverter.cs
+++ b/NowPlayingV2/UI/Extension/NullVisibilityConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Windows;
+using System.Windows.Data;
+
+namespace NowPlayingV2.UI.Extension
+{
+    public class NullVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value == null ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/NowPlayingV2/UI/Extension/NullVisibilityConverterReversed.cs
+++ b/NowPlayingV2/UI/Extension/NullVisibilityConverterReversed.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Windows;
+using System.Windows.Data;
+
+namespace NowPlayingV2.UI.Extension
+{
+    class NullVisibilityConverterReversed : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value != null ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/NowPlayingV2/UI/MainWindow.xaml
+++ b/NowPlayingV2/UI/MainWindow.xaml
@@ -39,7 +39,7 @@
                                    VerticalAlignment="Top" Width="250" Source="{Binding BsImage}" />
                             <Grid x:Name="NothingPlayingGrid" Height="100" HorizontalAlignment="Stretch"
                                   Background="#99000000">
-                                <Label Content="現在何も再生されていません。" FontSize="20" HorizontalAlignment="Center"
+                                <Label Content="現在何も再生されていません" FontSize="20" HorizontalAlignment="Center"
                                        VerticalAlignment="Center" />
                             </Grid>
                             <Grid x:Name="HintBoxGrid" Width="500" HorizontalAlignment="Left"

--- a/NowPlayingV2/UI/NotifyIcon/NotifyIconDic.xaml
+++ b/NowPlayingV2/UI/NotifyIcon/NotifyIconDic.xaml
@@ -1,8 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:NowPlayingV2.UI.NotifyIcon"
-                    xmlns:tb="http://www.hardcodet.net/taskbar"
-                    xmlns:extension="clr-namespace:NowPlayingV2.UI.Extension">
+                    xmlns:tb="http://www.hardcodet.net/taskbar">
     <tb:TaskbarIcon
         IconSource="pack://application:,,,/UI/NotifyIcon/nowplayingv2.ico"
         MenuActivation="RightClick"

--- a/NowPlayingV2/UI/NotifyIcon/NotifyIconDic.xaml
+++ b/NowPlayingV2/UI/NotifyIcon/NotifyIconDic.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:NowPlayingV2.UI.NotifyIcon"
-                    xmlns:tb="http://www.hardcodet.net/taskbar">
+                    xmlns:tb="http://www.hardcodet.net/taskbar"
+                    xmlns:extension="clr-namespace:NowPlayingV2.UI.Extension">
     <tb:TaskbarIcon
         IconSource="pack://application:,,,/UI/NotifyIcon/nowplayingv2.ico"
         MenuActivation="RightClick"
@@ -9,11 +10,14 @@
         x:Key="NPIcon">
         <tb:TaskbarIcon.ContextMenu>
             <ContextMenu>
+                <local:SmallNowplayingStatusView x:Name="SmallStatusView" MaxWidth="300" />
+                <Separator />
                 <MenuItem x:Name="OnTweetDialog" Header="ツイート画面を表示する(_T)" />
                 <MenuItem x:Name="OnTweetNow" Header="今すぐツイートする(_I)" />
-                <Separator/>
-                <MenuItem x:Name="IsAutoTweetEnabledMenuItem" IsCheckable="True" IsChecked="{Binding EnableAutoTweet}" Header="自動投稿を使用する(_J)"/>
-                <Separator/>
+                <Separator />
+                <MenuItem x:Name="IsAutoTweetEnabledMenuItem" IsCheckable="True" IsChecked="{Binding EnableAutoTweet}"
+                          Header="自動投稿を使用する(_J)" />
+                <Separator />
                 <MenuItem x:Name="OnOpenSetting" Header="設定画面を開く(_S)" />
                 <MenuItem x:Name="OnAppExit" Header="なうぷれTunesV2を終了する(_E)" />
                 <Separator x:Name="UpdateMenuSeparator" Visibility="Collapsed" />

--- a/NowPlayingV2/UI/NotifyIcon/NotifyIconManager.cs
+++ b/NowPlayingV2/UI/NotifyIcon/NotifyIconManager.cs
@@ -6,8 +6,10 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using Hardcodet.Wpf.TaskbarNotification;
+using MahApps.Metro.Controls;
 using NowPlayingCore.NowPlaying;
 using NowPlayingV2.Core;
+using NowPlayingV2.UI.View;
 
 namespace NowPlayingV2.UI.NotifyIcon
 {
@@ -42,6 +44,20 @@ namespace NowPlayingV2.UI.NotifyIcon
                         NPIcon.ShowBalloonTip("エラー", exception.Message, BalloonIcon.Info);
                     }
                 };
+            ((UserControl)LogicalTreeHelper.FindLogicalNode(NPIcon.ContextMenu, "SmallStatusView"))
+                .DataContext = null;
+            PipeListener.StaticPipeListener!.OnMusicPlay += StaticPipeListenerOnMusicPlay;
+        }
+
+        private void StaticPipeListenerOnMusicPlay(SongInfo songInfo)
+        {
+            // 表示用データを生成する
+            var songView = new Model4SongView(songInfo);
+            NPIcon.Invoke(() =>
+            {
+                ((UserControl) LogicalTreeHelper.FindLogicalNode(NPIcon.ContextMenu, "SmallStatusView"))
+                    .DataContext = songView;
+            });
         }
 
         public void DeleteIcon() => NPIcon.Dispose();

--- a/NowPlayingV2/UI/NotifyIcon/SmallNowplayingStatusView.xaml
+++ b/NowPlayingV2/UI/NotifyIcon/SmallNowplayingStatusView.xaml
@@ -1,0 +1,32 @@
+﻿<UserControl x:Class="NowPlayingV2.UI.NotifyIcon.SmallNowplayingStatusView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:NowPlayingV2.UI.NotifyIcon"
+             xmlns:extension="clr-namespace:NowPlayingV2.UI.Extension"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="250">
+    <UserControl.Resources>
+        <extension:NullVisibilityConverter x:Key="NullVisibilityConverter" />
+        <extension:NullVisibilityConverterReversed x:Key="NullVisibilityConverterReversed" />
+    </UserControl.Resources>
+    <StackPanel>
+        <Label HorizontalAlignment="Center" FontSize="14" Visibility="{Binding Converter={StaticResource NullVisibilityConverterReversed}}">現在何も再生されていません</Label>
+        <StackPanel Visibility="{Binding Converter={StaticResource NullVisibilityConverter}}">
+            <Image Height="150" Width="150" Source="{Binding BsImage}" />
+            <Label Name="SongNameLabel" FontSize="14">
+                <TextBlock TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
+                           Text="{Binding Title,FallbackValue='TRUE COLORS (M@STER VERSION)'}" />
+            </Label>
+            <Label Name="AlbumNameLabel" FontSize="10">
+                <TextBlock TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
+                           Text="{Binding Album,FallbackValue='THE IDOLM@STER CINDERELLA GIRLS STARLIGHT MASTER for the NEXT! 01 TRUE COLORS'}" />
+            </Label>
+            <Label Name="ArtistNameLabel" FontSize="10">
+                <TextBlock TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
+                           Text="{Binding Artist,FallbackValue='城ヶ崎美嘉 (CV: 佳村はるか)、高森藍子 (CV: 金子有希)、アナスタシア (CV: 上坂すみれ)、藤原肇 (CV: 鈴木みのり)、乙倉悠貴 (CV: 中島由貴)、黒埼ちとせ (CV: 佐倉薫)、白雪千夜 (CV: 関口理咲)、久川颯 (CV: 長江里加)、久川凪 (CV: 立花日菜)'}" />
+            </Label>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/NowPlayingV2/UI/NotifyIcon/SmallNowplayingStatusView.xaml.cs
+++ b/NowPlayingV2/UI/NotifyIcon/SmallNowplayingStatusView.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace NowPlayingV2.UI.NotifyIcon
+{
+    public partial class SmallNowplayingStatusView : UserControl
+    {
+        public SmallNowplayingStatusView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
何も再生してない時はコンテキストメニューのアイテムを非表示にしようかと思ったが、WPF側のバグなのか、非表示になっても表示する領域だけは何故か出てしまうので、何も再生してないということが分かるテキストを代わりに表示するようにした。